### PR TITLE
The comment will clarify the solution given

### DIFF
--- a/source/Filters/117-one-pole-one-zero-lp-hp.rst
+++ b/source/Filters/117-one-pole-one-zero-lp-hp.rst
@@ -107,6 +107,11 @@ Comments
     
     You can keep the norm = 1/(fSampling+fCut) if you like.
 
-another comment 
----------------
-The euqation of the original contributor is correct. It is a first order Butterworth-Filter H(s') = 1/(1+s') and than denormalized s' = s/wcut and transformed by the bilinear transform s = 2f_s (z-1)/(z+1). Only the tan-prewarp is missing for fcut/wcut. 
+- **Date**: 2006-07-21 09:07:12
+- **By**: JoergBitzer
+
+.. code-block:: text
+
+    The equation of the original contributor is correct. It is a first order Butterworth-Filter
+    H(s') = 1/(1+s') and then denormalized s' = s/wcut and transformed by the bilinear transform
+    s = 2f_s (z-1)/(z+1). Only the tan-prewarp is missing for fcut/wcut.

--- a/source/Filters/117-one-pole-one-zero-lp-hp.rst
+++ b/source/Filters/117-one-pole-one-zero-lp-hp.rst
@@ -107,3 +107,6 @@ Comments
     
     You can keep the norm = 1/(fSampling+fCut) if you like.
 
+another comment 
+---------------
+The euqation of the original contributor is correct. It is a first order Butterworth-Filter H(s') = 1/(1+s') and than denormalized s' = s/wcut and transformed by the bilinear transform s = 2f_s (z-1)/(z+1). Only the tan-prewarp is missing for fcut/wcut. 

--- a/source/Filters/117-one-pole-one-zero-lp-hp.rst
+++ b/source/Filters/117-one-pole-one-zero-lp-hp.rst
@@ -107,7 +107,7 @@ Comments
     
     You can keep the norm = 1/(fSampling+fCut) if you like.
 
-- **Date**: 2006-07-21 09:07:12
+- **Date**: 2020-05-23
 - **By**: JoergBitzer
 
 .. code-block:: text


### PR DESCRIPTION
the comment at the end is misleading. The original is correct, but the tan-prewarp is missing.