### PR TITLE
Update 16-allmost-ready-to-use-oscillators.rst - Fix typo of a missing `)`

### DIFF
--- a/source/Synthesis/16-allmost-ready-to-use-oscillators.rst
+++ b/source/Synthesis/16-allmost-ready-to-use-oscillators.rst
@@ -43,7 +43,7 @@
     {
             int i = (int) phase;
     
-            phase += (sampleRate/(float TableSize)/frequency;
+            phase += (sampleRate/(float)TableSize)/frequency;
     
             if(phase >= (float)TableSize)
                     phase -= (float)TableSize;


### PR DESCRIPTION
Fix typo of a missing `)`