### PR TITLE
docs: improve build instructions

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -8,8 +8,9 @@ Pull requests welcome!
 In order to build the HTML locally with python3:
 
 .. code-block:: bash
-    
-    python -m venv .env
+
+    python -m venv .venv
+    source .venv/bin/activate
     pip install -r requirements.txt
     make html
 


### PR DESCRIPTION
- Use .venv instead of .env as the virtual environment directory name to follow conventions and avoid confusion with dotenv files
- Add missing venv activation step